### PR TITLE
feat: improve themes section.

### DIFF
--- a/.project/known_issues.md
+++ b/.project/known_issues.md
@@ -7,3 +7,5 @@
 - themes contain more information than they need to, they only need light ID and state
 
 - themes section in UI is not mobile friendly at all
+
+- user can create a theme without selecting a scene, adding a theme with a blank light (probably also affects updating lights)

--- a/.project/known_issues.md
+++ b/.project/known_issues.md
@@ -1,6 +1,6 @@
 ## Known Issues
 
-- linting doesn't seem consistent across projects
+- linting doesn't seem consistent across projects, and still need the .vue extension?
 
 - occasionally nanoleaf brightness doesn't fire when changing colour, seems to be a race condition worth looking into
 

--- a/.project/roadmap.md
+++ b/.project/roadmap.md
@@ -18,13 +18,13 @@
 
 - could use some form of navigation aid or breadcrumb
 
+- could use some form of default layout component
+
 - scenes should have something to indicate what they look like in the UI
 
 - should be able to update lights one by one
 
 - user experience should be smoother: if off don't show inputs for lights
-
-- Could use some form of default layout component
 
 - Loading... and Submitting... messages should be replaced with icons
 

--- a/orchestration-ui/package-lock.json
+++ b/orchestration-ui/package-lock.json
@@ -2268,12 +2268,40 @@
       "dev": true
     },
     "axios": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
-      "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.1.tgz",
+      "integrity": "sha512-0BfJq4NSfQXd+SkFdrvFbG7addhYSBA2mQwISr46pD6E5iqkWg02RAs8vyTT/j0RTnoYmeXauBuSv1qKwR179g==",
       "requires": {
-        "follow-redirects": "^1.3.0",
-        "is-buffer": "^1.1.5"
+        "follow-redirects": "1.5.10",
+        "is-buffer": "^2.0.2"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "follow-redirects": {
+          "version": "1.5.10",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+          "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+          "requires": {
+            "debug": "=3.1.0"
+          }
+        },
+        "is-buffer": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
+          "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw=="
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
       }
     },
     "babel-code-frame": {
@@ -2660,16 +2688,16 @@
       "integrity": "sha512-rXqOmH1VilAt2DyPzluTi2blhk17bO7ef+zLLPlWvG494pDxcM234pJ8wTc/6R40UWizAIIMgxjvxZg5kmsbag=="
     },
     "bootstrap-vue": {
-      "version": "2.0.0-rc.22",
-      "resolved": "https://registry.npmjs.org/bootstrap-vue/-/bootstrap-vue-2.0.0-rc.22.tgz",
-      "integrity": "sha512-QA363prZJZ5HFzAPAlj93yy7FLOwPU0P465kaz8l9COa5t5q5az2X+lMgmlp5c1Fe8yBUhc316KM1itbJqzVUg==",
+      "version": "2.0.0-rc.24",
+      "resolved": "https://registry.npmjs.org/bootstrap-vue/-/bootstrap-vue-2.0.0-rc.24.tgz",
+      "integrity": "sha512-8rA/I9tOvpNVIuMKD3rdlrUqgVdPEw4vPI0X8OeFJcG2hHvCHeZDF7FmWqxSeehIrUHGDV17HlTGSuP/v1Sp5g==",
       "requires": {
         "@nuxt/opencollective": "^0.2.2",
         "bootstrap": "^4.3.1",
         "core-js": ">=2.6.5 <3.0.0",
         "popper.js": "^1.15.0",
-        "portal-vue": "^2.1.4",
-        "vue-functional-data-merge": "^2.0.7"
+        "portal-vue": "^2.1.5",
+        "vue-functional-data-merge": "^3.1.0"
       },
       "dependencies": {
         "core-js": {
@@ -3699,9 +3727,9 @@
       }
     },
     "consola": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/consola/-/consola-2.7.1.tgz",
-      "integrity": "sha512-u7JYs+HnMbZPD2cEuS1XHsLeqtazA0kd5lAk8r8DnnGdgNhOdb7DSubJ+QLdQkbtpmmxgp7gs8Ug44sCyY4FCQ=="
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/consola/-/consola-2.9.0.tgz",
+      "integrity": "sha512-34Iue+LRcWbndFIfZc5boNizWlsrRjqIBJZTe591vImgbnq7nx2EzlrLtANj9TH2Fxm7puFJBJAOk5BhvZOddQ=="
     },
     "console-browserify": {
       "version": "1.1.0",
@@ -6669,6 +6697,7 @@
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.6.1.tgz",
       "integrity": "sha512-t2JCjbzxQpWvbhts3l6SH1DKzSrx8a+SsaVf4h6bG4kOXUuPYS/kg2Lr4gQSb7eemaHqJkOThF1BGyjlUkO1GQ==",
+      "dev": true,
       "requires": {
         "debug": "=3.1.0"
       },
@@ -6677,6 +6706,7 @@
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
           "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
           "requires": {
             "ms": "2.0.0"
           }
@@ -6684,7 +6714,8 @@
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
         }
       }
     },
@@ -8858,7 +8889,8 @@
     "is-buffer": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "dev": true
     },
     "is-callable": {
       "version": "1.1.4",
@@ -15005,9 +15037,9 @@
       }
     },
     "vue-functional-data-merge": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/vue-functional-data-merge/-/vue-functional-data-merge-2.0.7.tgz",
-      "integrity": "sha512-pvLc+H+x2prwBj/uSEIITyxjz/7ZUVVK8uYbrYMmhDvMXnzh9OvQvVEwcOSBQjsubd4Eq41/CSJaWzy4hemMNQ=="
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/vue-functional-data-merge/-/vue-functional-data-merge-3.1.0.tgz",
+      "integrity": "sha512-leT4kdJVQyeZNY1kmnS1xiUlQ9z1B/kdBFCILIjYYQDqZgLqCLa0UhjSSeRX6c3mUe6U5qYeM8LrEqkHJ1B4LA=="
     },
     "vue-hot-reload-api": {
       "version": "2.3.1",

--- a/orchestration-ui/package.json
+++ b/orchestration-ui/package.json
@@ -10,7 +10,7 @@
 	},
 	"dependencies": {
 		"axios": "0.18.1",
-		"bootstrap-vue": "2.0.0-rc.22",
+		"bootstrap-vue": "2.0.0-rc.24",
 		"firebase": "6.1.1",
 		"lodash": "^4.17.11",
 		"register-service-worker": "^1.5.2",

--- a/orchestration-ui/src/App.vue
+++ b/orchestration-ui/src/App.vue
@@ -32,6 +32,7 @@ export default {
 
 	&__content {
 		width: 100%;
+		overflow: auto;
 	}
 }
 

--- a/orchestration-ui/src/containers/Lights/Control.vue
+++ b/orchestration-ui/src/containers/Lights/Control.vue
@@ -3,59 +3,49 @@
 
 		<section class="Lights__header">
 
-			<div>
+			<h2>Lights</h2>
+
+			<div class="Lights__header__buttons">
 				<b-button
 					class="Lights__header__button"
 					variant="info"
 					v-text="'Refresh'"
 					@click="fetchLightsAndSetupPage"/>
+
+				<b-btn
+					v-if="!page.isSubmitting"
+					class="Lights__header__button"
+					variant="primary"
+					v-text="'Update Lights'"
+					@click="submit"/>
 			</div>
-
-
-			<h2>Lights</h2>
 
 		</section>
 
 		<span
 			v-if="page.isLoading"
 			v-text="'Loading...'"/>
+		<span
+			v-if="page.isSubmitting"
+			v-text="'Submitting...'"/>
 
+		<light-list
+			v-if="!page.isLoading && !page.isSubmitting"
+			v-model="lightsInputs"/>
 
-		<template v-if="!page.isLoading">
-
-			<section class="Lights__lights">
-
-				<light
-					v-for="(light, i) in lightsInputs"
-					:key="light.name"
-					class="Lights__light"
-					v-model="lightsInputs[i]"/>
-
-			</section>
-
-			<p v-if="page.isSubmitting" v-text="'Submitting...'"/>
-			<b-btn
-				v-else
-				size="lg"
-				variant="primary"
-				v-text="'Apply Changes'"
-				:disabled="isUpdateButtonDisabled"
-				@click="submit"/>
-
-		</template>
 
 	</b-container>
 </template>
 
 <script>
-import { cloneDeep, isEqual } from 'lodash';
+import { cloneDeep } from 'lodash';
 import { mapGetters, mapActions } from 'vuex';
 import toastService from '../../lib/toastService';
-import Light from './components/Light.vue';
+import LightList from './components/LightList.vue';
 
 export default {
 	components: {
-		Light
+		LightList
 	},
 	data() {
 		return {
@@ -69,10 +59,7 @@ export default {
 	computed: {
 		...mapGetters({
 			lights: 'lights/lights'
-		}),
-		isUpdateButtonDisabled() {
-			return isEqual(this.lights, this.lightsInputs);
-		}
+		})
 	},
 	methods: {
 		...mapActions({
@@ -113,34 +100,27 @@ export default {
 
 	&__header {
 		display: flex;
-		flex-direction: row-reverse;
+		flex-direction: column;
 		justify-content: space-between;
 		margin-bottom: 1rem;
-
-		&__button {
-			margin-left: 1rem;
-		}
-	}
-
-	&__lights {
-		margin-bottom: 2rem;
-		display: flex;
-		flex-direction: column;
 
 		@media all and (min-width: 768px) {
 			flex-direction: row;
 		}
-	}
 
-	&__light {
-		width: 100%;
-		margin-bottom: 1rem;
+		&__buttons {
+			display: flex;
+			flex-direction: column;
+		}
 
-		@media all and (min-width: 768px) {
-			margin: 0 1rem;
+		&__button {
+			margin-bottom: 1rem;
 
-			&:first-of-type { margin-left: 0; }
-			&:last-of-type { margin-right: 0; }
+			@media all and (min-width: 768px) {
+				margin-bottom: 0;
+				margin-left: 1rem;
+			}
+
 		}
 	}
 }

--- a/orchestration-ui/src/containers/Lights/Control.vue
+++ b/orchestration-ui/src/containers/Lights/Control.vue
@@ -111,6 +111,10 @@ export default {
 		&__buttons {
 			display: flex;
 			flex-direction: column;
+
+			@media all and (min-width: 768px) {
+				flex-direction: row;
+			}
 		}
 
 		&__button {

--- a/orchestration-ui/src/containers/Lights/components/Light.vue
+++ b/orchestration-ui/src/containers/Lights/components/Light.vue
@@ -156,31 +156,52 @@ export default {
 <style lang="scss">
 
 .Light {
-	min-height: 22rem;
+
+	@media all and (min-width: 768px) {
+		min-height: 20rem;
+	}
 
 	&__inner {
 		display: flex;
 		flex-direction: column;
 		align-items: center;
+
+		@media all and (min-width: 768px) {
+			flex-direction: row;
+			justify-content: space-between;
+		}
 	}
 
 	&__label {
 		width: 100%;
+
+		@media all and (min-width: 768px) {
+			width: auto;
+		}
 	}
 
 	&__items {
 		height: 100%;
 		display: flex;
 		flex-direction: column;
-		justify-content: space-around;
+
+		@media all and (min-width: 768px) {
+			min-width: 26rem;
+			flex-direction: row;
+			justify-content: space-around;
+		}
 	}
 
 	&__item {
-		padding: 1rem;
+		padding: 1rem 0;
 		display: flex;
 		flex-direction: column;
 		justify-content: center;
 		align-items: center;
+
+		@media all and (min-width: 768px) {
+			padding: 0 1rem;
+		}
 	}
 
 	&__controls {

--- a/orchestration-ui/src/containers/Lights/components/Light.vue
+++ b/orchestration-ui/src/containers/Lights/components/Light.vue
@@ -193,15 +193,11 @@ export default {
 	}
 
 	&__item {
-		padding: 1rem 0;
+		padding: 1rem;
 		display: flex;
 		flex-direction: column;
 		justify-content: center;
 		align-items: center;
-
-		@media all and (min-width: 768px) {
-			padding: 0 1rem;
-		}
 	}
 
 	&__controls {

--- a/orchestration-ui/src/containers/Lights/components/Light.vue
+++ b/orchestration-ui/src/containers/Lights/components/Light.vue
@@ -198,6 +198,10 @@ export default {
 		flex-direction: column;
 		justify-content: center;
 		align-items: center;
+
+		@media all and (min-width: 768px) {
+			padding: 0 1rem;
+		}
 	}
 
 	&__controls {

--- a/orchestration-ui/src/containers/Lights/components/LightList.vue
+++ b/orchestration-ui/src/containers/Lights/components/LightList.vue
@@ -1,0 +1,55 @@
+<template>
+	<section class="LightsList">
+
+		<light
+			v-for="(light, i) in inputVal"
+			:key="light.name"
+			class="LightsList__item"
+			v-model="inputVal[i]"/>
+
+	</section>
+</template>
+
+<script>
+import Light from './Light.vue';
+
+export default {
+	components: {
+		Light
+	},
+	props: {
+		value: {
+			required: true,
+			type: Array
+		}
+	},
+	data() {
+		return {
+			inputVal: this.value
+		};
+	},
+	watch: {
+		inputVal(v) {
+			this.$emit('input', v);
+		},
+		value: {
+			immediate: true,
+			handler() {
+				this.inputVal = this.value;
+			}
+		}
+	}
+};
+</script>
+
+<style lang="scss">
+.LightsList {
+	display: flex;
+	flex-direction: column;
+
+	&__item {
+		width: 100%;
+		margin-bottom: 1rem;
+	}
+}
+</style>

--- a/orchestration-ui/src/containers/Lights/index.js
+++ b/orchestration-ui/src/containers/Lights/index.js
@@ -1,10 +1,10 @@
-import Page from './Page.vue';
+import Control from './Control.vue';
 
 const routes = [
 	{
-		name: 'lights.page',
+		name: 'lights.control',
 		path: '/lights',
-		component: Page,
+		component: Control,
 		menuName: 'Lights'
 	}
 ];

--- a/orchestration-ui/src/containers/Themes/Edit.vue
+++ b/orchestration-ui/src/containers/Themes/Edit.vue
@@ -5,7 +5,9 @@
 
 			<section class="ThemesEdit__header">
 
-				<div>
+				<h2 v-text="titleText"/>
+
+				<div class="ThemesEdit__header__buttons">
 
 					<b-button
 						class="ThemesEdit__header__button"
@@ -38,8 +40,6 @@
 						@click="onUpdateClick"/>
 
 				</div>
-
-				<h2 v-text="titleText"/>
 
 			</section>
 
@@ -200,12 +200,31 @@ export default {
 
 	&__header {
 		display: flex;
-		flex-direction: row-reverse;
+		flex-direction: column;
 		justify-content: space-between;
 		margin-bottom: 1rem;
 
+		@media all and (min-width: 768px) {
+			flex-direction: row;
+		}
+
+		&__buttons {
+			display: flex;
+			flex-direction: column;
+
+			@media all and (min-width: 768px) {
+				flex-direction: row;
+			}
+		}
+
 		&__button {
-			margin-left: 1rem;
+			margin-bottom: 1rem;
+
+			@media all and (min-width: 768px) {
+				margin-bottom: 0;
+				margin-left: 1rem;
+			}
+
 		}
 	}
 

--- a/orchestration-ui/src/containers/Themes/Edit.vue
+++ b/orchestration-ui/src/containers/Themes/Edit.vue
@@ -1,80 +1,95 @@
 <template>
-	<b-container class="ThemesEdit">
+	<div class="ThemesEdit">
 
-		<section class="ThemesEdit__header">
+		<b-container class="ThemesEdit__content">
 
-			<div>
+			<section class="ThemesEdit__header">
 
-				<b-button
-					class="ThemesEdit__header__button"
-					variant="info"
-					v-text="'List View'"
-					:to="{ name: 'themes.list' }"/>
+				<div>
 
-				<b-button
-					v-if="!isInCreateMode"
-					class="ThemesEdit__header__button"
-					variant="danger"
-					v-text="'Delete Theme'"
-					:disabled="page.isSubmitting"
-					@click="onDeleteClick"/>
+					<b-button
+						class="ThemesEdit__header__button"
+						variant="info"
+						v-text="'List View'"
+						:to="{ name: 'themes.list' }"/>
 
-				<b-button
-					v-if="isInCreateMode"
-					class="ThemesEdit__header__button"
-					variant="outline-primary"
-					v-text="'Create Theme'"
-					:disabled="isSubmitDisabled"
-					@click="onCreateClick"/>
+					<b-button
+						v-if="!isInCreateMode"
+						class="ThemesEdit__header__button"
+						variant="danger"
+						v-text="'Delete Theme'"
+						:disabled="page.isSubmitting"
+						@click="openConfirmDeleteModal"/>
 
-				<b-button
-					v-if="!isInCreateMode"
-					class="ThemesEdit__header__button"
-					variant="primary"
-					v-text="'Update Theme'"
-					:disabled="isSubmitDisabled"
-					@click="onUpdateClick"/>
+					<b-button
+						v-if="isInCreateMode"
+						class="ThemesEdit__header__button"
+						variant="outline-primary"
+						v-text="'Create Theme'"
+						:disabled="isSubmitDisabled"
+						@click="onCreateClick"/>
 
-			</div>
+					<b-button
+						v-if="!isInCreateMode"
+						class="ThemesEdit__header__button"
+						variant="outline-info"
+						v-text="'Update Theme'"
+						:disabled="isSubmitDisabled"
+						@click="onUpdateClick"/>
 
-			<h2 v-text="titleText"/>
-
-		</section>
-
-		<span
-			v-if="page.isLoading"
-			v-text="'Loading...'"/>
-
-		<span
-			v-if="page.isSubmitting"
-			v-text="'Submitting...'"/>
-
-		<template v-if="!page.isLoading && !page.isSubmitting">
-
-			<b-form-group
-				label="Name"
-				label-for="ThemesEdit__name">
-				<b-form-input
-					id="ThemesEdit__name"
-					v-model="themeInput.name"
-					trim/>
-			</b-form-group>
-
-			<section>
-				<h3>Lights</h3>
-				<div class="ThemesEdit__lights">
-
-					<light
-						v-for="(light, i) in themeInput.lights"
-						:key="light.name"
-						class="ThemesEdit__lights__item"
-						v-model="themeInput.lights[i]"/>
 				</div>
+
+				<h2 v-text="titleText"/>
+
 			</section>
 
-		</template>
+			<span
+				v-if="page.isLoading"
+				v-text="'Loading...'"/>
 
-	</b-container>
+			<span
+				v-if="page.isSubmitting"
+				v-text="'Submitting...'"/>
+
+			<template v-if="!page.isLoading && !page.isSubmitting">
+
+				<b-form-group
+					label="Name"
+					label-for="ThemesEdit__name">
+					<b-form-input
+						id="ThemesEdit__name"
+						v-model="themeInput.name"
+						trim/>
+				</b-form-group>
+
+				<section>
+					<h3>Lights</h3>
+					<div class="ThemesEdit__lights">
+						<light
+							v-for="(light, i) in themeInput.lights"
+							:key="light.name"
+							class="ThemesEdit__lights__item"
+							v-model="themeInput.lights[i]"/>
+					</div>
+				</section>
+
+			</template>
+
+		</b-container>
+
+		<b-modal
+			:visible="page.isConfirmDeleteModalVisible"
+			title="Delete Theme"
+			header-text-variant="light"
+			header-bg-variant="danger"
+			ok-variant="danger"
+			cancel-variant="info"
+			@ok="onDeleteClick"
+			@hidden="hideConfirmDeleteModal">
+			<span v-text="'Are you sure you want to delete this theme?'"/>
+		</b-modal>
+
+	</div>
 </template>
 
 <script>
@@ -91,7 +106,8 @@ export default {
 		return {
 			page: {
 				isLoading: false,
-				isSubmitting: false
+				isSubmitting: false,
+				isConfirmDeleteModalVisible: false
 			},
 			themeInput: {}
 		};
@@ -163,6 +179,12 @@ export default {
 				toastService.toast(err.message);
 			}
 			this.page.isSubmitting = false;
+		},
+		openConfirmDeleteModal() {
+			this.page.isConfirmDeleteModalVisible = true;
+		},
+		hideConfirmDeleteModal() {
+			this.page.isConfirmDeleteModalVisible = false;
 		}
 	},
 	created() {
@@ -175,9 +197,12 @@ export default {
 <style lang="scss">
 
 .ThemesEdit {
-	margin-top: 1rem;
-	display: flex;
-	flex-direction: column;
+
+	&__content {
+		margin-top: 1rem;
+		display: flex;
+		flex-direction: column;
+	}
 
 	&__header {
 		display: flex;

--- a/orchestration-ui/src/containers/Themes/Edit.vue
+++ b/orchestration-ui/src/containers/Themes/Edit.vue
@@ -64,13 +64,7 @@
 
 				<section>
 					<h3>Lights</h3>
-					<div class="ThemesEdit__lights">
-						<light
-							v-for="(light, i) in themeInput.lights"
-							:key="light.name"
-							class="ThemesEdit__lights__item"
-							v-model="themeInput.lights[i]"/>
-					</div>
+					<light-list v-model="themeInput.lights"/>
 				</section>
 
 			</template>
@@ -96,11 +90,11 @@
 import { cloneDeep } from 'lodash';
 import { mapGetters, mapActions } from 'vuex';
 import toastService from '../../lib/toastService';
-import Light from '../Lights/components/Light.vue';
+import LightList from '../Lights/components/LightList.vue';
 
 export default {
 	components: {
-		Light
+		LightList
 	},
 	data() {
 		return {

--- a/orchestration-ui/src/containers/Themes/List.vue
+++ b/orchestration-ui/src/containers/Themes/List.vue
@@ -88,7 +88,8 @@
 
 						<span
 							v-if="data.item.isSubmitting"
-							v-text="'Submitting'"/>
+							class="ThemesList__table__actions__item"
+							v-text="'Submitting...'"/>
 
 					</div>
 

--- a/orchestration-ui/src/containers/Themes/List.vue
+++ b/orchestration-ui/src/containers/Themes/List.vue
@@ -7,15 +7,15 @@
 
 				<b-button
 					class="ThemesList__header__button"
-					variant="outline-info"
-					v-text="'New Theme'"
-					:to="{ name: 'themes.create' }"/>
-
-				<b-button
-					class="ThemesList__header__button"
 					variant="info"
 					v-text="'Refresh'"
 					@click="fetchThemesAndSetupPage"/>
+
+				<b-button
+					class="ThemesList__header__button"
+					variant="outline-info"
+					v-text="'New Theme'"
+					:to="{ name: 'themes.create' }"/>
 
 			</div>
 
@@ -47,18 +47,22 @@
 						<b
 							class="ThemesList__table__lights__item"
 							v-text="`${light.name}:`"/>
-						<span
-							class="ThemesList__table__lights__item"
-							v-if="light.state.colour"
-							v-text="`Colour: ${light.state.colour};`"/>
-						<span
-							class="ThemesList__table__lights__item"
-							v-if="light.state.brightness"
-							v-text="`Brightness: ${light.state.brightness};`"/>
-						<span
-							class="ThemesList__table__lights__item"
-							v-if="light.state.scene"
-							v-text="`Scene: ${light.state.scene};`"/>
+
+						<span v-if="!light.state.on" v-text="'off'"/>
+						<template v-else>
+							<span
+								class="ThemesList__table__lights__item"
+								v-if="light.state.colour"
+								v-text="`colour: ${light.state.colour};`"/>
+							<span
+								class="ThemesList__table__lights__item"
+								v-if="light.state.brightness"
+								v-text="`brightness: ${light.state.brightness};`"/>
+							<span
+								class="ThemesList__table__lights__item"
+								v-if="light.state.scene"
+								v-text="`scene: ${light.state.scene};`"/>
+						</template>
 					</div>
 
 				</template>

--- a/orchestration-ui/src/containers/Themes/List.vue
+++ b/orchestration-ui/src/containers/Themes/List.vue
@@ -3,7 +3,9 @@
 
 		<section class="ThemesList__header">
 
-			<div>
+			<h2>Themes</h2>
+
+			<div class="ThemesList__header__buttons">
 
 				<b-button
 					class="ThemesList__header__button"
@@ -18,8 +20,6 @@
 					:to="{ name: 'themes.create' }"/>
 
 			</div>
-
-			<h2>Themes</h2>
 
 		</section>
 
@@ -161,12 +161,31 @@ export default {
 
 	&__header {
 		display: flex;
-		flex-direction: row-reverse;
+		flex-direction: column;
 		justify-content: space-between;
 		margin-bottom: 1rem;
 
+		@media all and (min-width: 768px) {
+			flex-direction: row;
+		}
+
+		&__buttons {
+			display: flex;
+			flex-direction: column;
+
+			@media all and (min-width: 768px) {
+				flex-direction: row;
+			}
+		}
+
 		&__button {
-			margin-left: 1rem;
+			margin-bottom: 1rem;
+
+			@media all and (min-width: 768px) {
+				margin-bottom: 0;
+				margin-left: 1rem;
+			}
+
 		}
 	}
 

--- a/orchestration-ui/src/containers/Themes/index.js
+++ b/orchestration-ui/src/containers/Themes/index.js
@@ -4,7 +4,7 @@ import Edit from './Edit.vue';
 const routes = [
 	{
 		name: 'themes.list',
-		path: '/theme',
+		path: '/themes',
 		component: List,
 		menuName: 'Themes'
 	},

--- a/orchestration-ui/src/main.js
+++ b/orchestration-ui/src/main.js
@@ -1,6 +1,7 @@
 import Vue from 'vue';
 import Vuex from 'vuex';
 import BootstrapVue from 'bootstrap-vue';
+import 'bootstrap-vue/dist/bootstrap-vue.css';
 import VueToasted from 'vue-toasted';
 import App from './App.vue';
 import router from './router';

--- a/orchestration-ui/src/router/routes.js
+++ b/orchestration-ui/src/router/routes.js
@@ -9,7 +9,7 @@ const routes = [
 	...themesRoutes,
 	{
 		path: '*',
-		redirect: { name: 'lights.page' }
+		redirect: { name: 'lights.control' }
 	}
 ];
 


### PR DESCRIPTION
This is part of the work effort outlined in #6 and in particular addresses the issues outlined in this comment: https://github.com/michaelfitzhavey/home-orchestrator/issues/6#issuecomment-502944679

## Changes
### Features:
- deleting a theme is protected behind a confirmation modal
- minor design improvements:
    - swap refresh and new theme button positions
    - apply theme submitting state is now consistent
    - lights list now shows items horizontally on desktop
    - header buttons stack on mobile
    - theme section made mobile friendly
### Fixes:
- correctly show when a light is off in the themes list
- fix capitalisation of properties in themes list
- path to themes section updated from `/theme` to `/themes`
### Chores:
- renamed `light.page` to `light.control`
- refactored lights into LightList to be used on light control page and create theme page